### PR TITLE
chore: streamline CI dependency installation

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install dependencies
-        run: go get . && go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@latest
 
       - name: Run unit tests
         run: gotestsum --format testname
@@ -55,7 +55,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install dependencies
-        run: go get .
+        run: make deps
 
       - name: Generate Documentation
         run: make generate-doc


### PR DESCRIPTION
## Summary

Cleaned up CI dependency installation steps to be more efficient and consistent:

**Test Job:**
- Removed redundant `go get .` 
- Now only installs `gotestsum` (the actual tool we need)
- Faster, cleaner, and doesn't waste cycles resolving dependencies we already have

**Docs Job:**
- Replaced `go get .` with `make deps`
- Now uses the same dependency installation method as local development
- Consistency between CI and dev environments = fewer "works on my machine" moments

Both changes reduce unnecessary overhead and make the workflow more maintainable.

**Changed Files:**
- `.github/workflows/gh-pages.yaml` - Updated dependency installation in both jobs